### PR TITLE
fix appcleaner to remove only user-application containers

### DIFF
--- a/src/appcleaner.sh
+++ b/src/appcleaner.sh
@@ -1,15 +1,28 @@
 #!/bin/sh
 CLEAN_INTERVAL=${CLEAN_INTERVAL:-"30"}
+
+get_containers() {
+	# Docker 1.9.0 added the feature of filtering by labels, which simplifies
+	# the code below (at least when I committed this) to just the following
+	# line:
+	#     docker ps -q -a -f "status=exited" -f "label=com.eyeos.container-type=user-application"
+	# If we upgrade the requirements to require at least docker 1.9 we could
+	# use that line.
+	docker ps -a \
+		--filter="status=exited" \
+		--format='{{.ID}} {{.Label "com.eyeos.container-type"}}' \
+		| while read container_id container_type
+		do
+			if [ "$container_type" = "user-application" ]
+			then
+				echo "$container_id"
+			fi
+		done
+}
+
 while :
 do
-	TOBEDELETED=$(docker ps -q -a -f "status=exited" -f "ancestor=docker-registry.eyeosbcn.com/open365-app-docker")
-	AMOUNT=$(docker ps -q -a -f "status=exited" -f "ancestor=docker-registry.eyeosbcn.com/open365-app-docker" | wc -l)
-	if [ ! -z "$TOBEDELETED" ]; then
-		echo "Deleting $AMOUNT containers"
-		docker rm $TOBEDELETED
-	else
-		echo "No container to be deleted"
-	fi
+	get_containers | xargs --no-run-if-empty docker rm
 	echo "Waiting for next loop $CLEAN_INTERVAL seconds"
 	sleep $CLEAN_INTERVAL
 done


### PR DESCRIPTION
in docker <= 1.9 the 'ancestor' filter didn't exist, so docker was
ignoring it and removing all exited containers wether they were from
users or from backend services. Also, the open365-app-docker image has
not existed for quite some time, so in docker >= 1.9 what happened was
that no image was being removed.

We have fixed everything by setting a label only to user-containers and
just removing the exited containers that have that label.
